### PR TITLE
Add /rebase github action PR command

### DIFF
--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -1,0 +1,16 @@
+on:
+  issue_comment:
+    types: [created]
+
+name: PR commands
+jobs:
+  rebase:
+    name: Rebase
+    if: contains(github.event.comment.body, '/rebase')
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Automatic Rebase
+      uses: cirrus-actions/rebase@1.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/repo-quality.yml
+++ b/.github/workflows/repo-quality.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     paths-ignore:
       - '.github/workflows/update-build-containers.yaml'
+      - '.github/workflows/pr-commands.yaml'
       - 'po/*'
 jobs:
 


### PR DESCRIPTION
This allows us or users to easily rebase a branch on latest master.
Then, the new push will make CI running again.