### PR TITLE
Improved logging for getDependencies

### DIFF
--- a/internal/machines/internal_test.go
+++ b/internal/machines/internal_test.go
@@ -197,7 +197,7 @@ func TestGetDependencies(t *testing.T) {
 			}
 			s := ms.getStateFromName(t, tc.stateName)
 
-			stateDeps, datasetDeps := s.getDependencies(&ms)
+			stateDeps, datasetDeps := s.getDependencies(context.Background(), &ms)
 
 			stateNames := make([]string, len(stateDeps))
 			for i, s := range stateDeps {

--- a/internal/zfs/zfs_test.go
+++ b/internal/zfs/zfs_test.go
@@ -776,7 +776,9 @@ func TestDependencies(t *testing.T) {
 				t.Fatalf("No dataset found matching %s", tc.depsFor)
 			}
 
-			deps := d.Dependencies(z)
+			nt := z.NewNoTransaction(context.Background())
+
+			deps := nt.Dependencies(*d)
 
 			// We can’t rely on the order of the original list, as we iterate over maps in the implementation.
 			// However, we identified 3 rules to ensure that the dependency order (from leaf to root) is respected.


### PR DESCRIPTION
the API of getDependencies has been updated to retrieve a context and
enable logging in getDependencies.
More debug logging has been added to dependency calculation code.

Co-authored-by: Didier Roche <didrocks@ubuntu.com>