### PR TITLE
More polish

### DIFF
--- a/cmd/zsysd/client/state.go
+++ b/cmd/zsysd/client/state.go
@@ -150,6 +150,11 @@ func saveState(args []string, system bool, userName string, noUpdateBootMenu, sa
 		}
 	}
 
+	// Non zsys system: exit
+	if stateName == "" {
+		return nil
+	}
+
 	fmt.Printf(i18n.G("Successfully saved as %q\n"), stateName)
 
 	return nil

--- a/internal/machines/machines.go
+++ b/internal/machines/machines.go
@@ -673,7 +673,9 @@ func (m Machine) Info(full bool) (string, error) {
 	}
 
 	// History
-	fmt.Fprintf(w, i18n.G("History:\n"))
+	if len(m.History) > 0 {
+		fmt.Fprintf(w, i18n.G("History:\t\n"))
+	}
 	timeToState := make(map[string]*State)
 	for id, s := range m.History {
 		k := fmt.Sprintf("%010d_%s", s.LastUsed.Unix(), id)
@@ -701,12 +703,9 @@ func (m Machine) Info(full bool) (string, error) {
 	for _, user := range keys {
 		fmt.Fprintf(w, i18n.G("  - Name:\t%s\n"), user)
 
-		if len(m.AllUsersStates[user]) == 0 {
-			fmt.Fprintf(w, i18n.G("    History:\tEmpty\n"))
-			continue
+		if len(m.AllUsersStates[user]) > 1 {
+			fmt.Fprintf(w, i18n.G("    History:\t\n"))
 		}
-
-		fmt.Fprintf(w, i18n.G("    History:\t\n"))
 
 		timeToState := make(map[string]*State)
 	nextUserState:


### PR DESCRIPTION
* Fix history label showing up when no history was available  
    Use the same format for both: "History:\t\n"
    Fix off by one error
* Only print generated names on state save when generated
    Handle empty name which is returned on success with a nil error on non
    zsys systems.
