### PR TITLE
Close socket when the service stops

### DIFF
--- a/systemd/zsysd.socket
+++ b/systemd/zsysd.socket
@@ -1,6 +1,6 @@
 [Unit]
 Description=Socker activation for zsys daemon
-PartOf=zsyd.service
+PartOf=zsysd.service
 
 [Socket]
 ListenStream=/run/zsysd.sock


### PR DESCRIPTION
There's a typo in the zsys socket's unit file that is preventing the unix socket from being closed when the zsys service is stopped.  This tiny change fixes that.
