### PR TITLE
Prevent segfault immediately after install when zfs kernel module isn't loaded

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,6 +20,7 @@ Built-Using: ${misc:Built-Using},
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          grub2-common,
+Recommends: zfsutils-linux
 Description: ZFS SYStem integration
  ZSYS is a Zfs SYStem tool targetting an enhanced ZOL experience.
  It allows running multiple ZFS system in parallels on the same machine,

--- a/debian/zsys.postinst
+++ b/debian/zsys.postinst
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# The zsysd service fails to start if the zfs kernel module is not loaded,
+# so we make sure it's loaded here first.
+modprobe -v zfs || true
+
+#DEBHELPER#


### PR DESCRIPTION
It appears that zsys requires zfsutils-linux, otherwise the daemon fails to start.  Tested from the Kubuntu focal installer live environment, where ZFS is not preinstalled:
```console
kubuntu@kubuntu:~$ sudo apt-get install zsys
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following additional packages will be installed:
  libnvpair1linux libuutil1linux libzfs2linux
The following NEW packages will be installed:
  libnvpair1linux libuutil1linux libzfs2linux zsys
0 upgraded, 4 newly installed, 0 to remove and 19 not upgraded.
Need to get 3,910 kB of archives.
After this operation, 14.0 MB of additional disk space will be used.
Do you want to continue? [Y/n] y
Get:1 http://archive.ubuntu.com/ubuntu focal/main amd64 libnvpair1linux amd64 0.8.3-1ubuntu12 [48.4 kB]
Get:2 http://archive.ubuntu.com/ubuntu focal/main amd64 libuutil1linux amd64 0.8.3-1ubuntu12 [41.8 kB]
Get:3 http://archive.ubuntu.com/ubuntu focal/main amd64 libzfs2linux amd64 0.8.3-1ubuntu12 [207 kB]
Get:4 http://archive.ubuntu.com/ubuntu focal/main amd64 zsys amd64 0.4.4 [3,613 kB]
Fetched 3,910 kB in 1s (3,847 kB/s)
Selecting previously unselected package libnvpair1linux.
(Reading database ... 205941 files and directories currently installed.)
Preparing to unpack .../libnvpair1linux_0.8.3-1ubuntu12_amd64.deb ...
Unpacking libnvpair1linux (0.8.3-1ubuntu12) ...
Selecting previously unselected package libuutil1linux.
Preparing to unpack .../libuutil1linux_0.8.3-1ubuntu12_amd64.deb ...
Unpacking libuutil1linux (0.8.3-1ubuntu12) ...
Selecting previously unselected package libzfs2linux.
Preparing to unpack .../libzfs2linux_0.8.3-1ubuntu12_amd64.deb ...
Unpacking libzfs2linux (0.8.3-1ubuntu12) ...
Selecting previously unselected package zsys.
Preparing to unpack .../archives/zsys_0.4.4_amd64.deb ...
Unpacking zsys (0.4.4) ...
Setting up libuutil1linux (0.8.3-1ubuntu12) ...
Setting up libnvpair1linux (0.8.3-1ubuntu12) ...
Setting up libzfs2linux (0.8.3-1ubuntu12) ...
Setting up zsys (0.4.4) ...
Created symlink /etc/systemd/user/timers.target.wants/zsys-user-savestate.timer → /usr/lib/systemd/user/zsys-user-savestate.timer.
Created symlink /etc/systemd/system/default.target.wants/zsys-commit.service → /lib/systemd/system/zsys-commit.service.
Created symlink /etc/systemd/system/timers.target.wants/zsys-gc.timer → /lib/systemd/system/zsys-gc.timer.
Created symlink /etc/systemd/system/sockets.target.wants/zsysd.socket → /lib/systemd/system/zsysd.socket.
zsys-gc.service is a disabled or a static unit, not starting it.
zsysd.service is a disabled or a static unit, not starting it.
Job for zsys-commit.service failed because the control process exited with error code.
See "systemctl status zsys-commit.service" and "journalctl -xe" for details.
Processing triggers for man-db (2.9.1-1) ...
Processing triggers for libc-bin (2.31-0ubuntu7) ...

kubuntu@kubuntu:~$ sudo zsysctl list
ERROR couldn't connect to zsys daemon: connection closed 

kubuntu@kubuntu:~$ systemctl status zsysd.socket
● zsysd.socket - Socker activation for zsys daemon
     Loaded: loaded (/lib/systemd/system/zsysd.socket; enabled; vendor preset: enabled)
     Active: failed (Result: service-start-limit-hit) since Thu 2020-04-16 22:10:34 UTC; 3s ago
   Triggers: ● zsysd.service
     Listen: /run/zsysd.sock (Stream)
```

The zsys daemon fails to start due to a segfault, and systemd eventually gives up on restarting it:
```console
kubuntu@kubuntu:~$ journalctl -u zsysd --no-pager
-- Logs begin at Thu 2020-04-16 21:37:36 UTC, end at Thu 2020-04-16 22:07:35 UTC. --
Apr 16 21:43:58 kubuntu systemd[1]: Starting ZSYS daemon service...
Apr 16 21:43:58 kubuntu zsysd[12777]: fatal error: unexpected signal during runtime execution
Apr 16 21:43:58 kubuntu zsysd[12777]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x7f4d7df5a7b0]
Apr 16 21:43:58 kubuntu zsysd[12777]: runtime stack:
Apr 16 21:43:58 kubuntu zsysd[12777]: runtime.throw(0xb07761, 0x2a)
Apr 16 21:43:58 kubuntu zsysd[12777]:         runtime/panic.go:774 +0x72
Apr 16 21:43:58 kubuntu zsysd[12777]: runtime.sigpanic()
Apr 16 21:43:58 kubuntu zsysd[12777]:         runtime/signal_unix.go:378 +0x47c
Apr 16 21:43:58 kubuntu zsysd[12777]: goroutine 1 [syscall]:
Apr 16 21:43:58 kubuntu zsysd[12777]: runtime.cgocall(0x983aa0, 0xc0001133f8, 0x7f4d7d8096d0)
Apr 16 21:43:58 kubuntu zsysd[12777]:         runtime/cgocall.go:128 +0x5b fp=0xc0001133c8 sp=0xc000113390 pc=0x40a93b
Apr 16 21:43:58 kubuntu zsysd[12777]: github.com/ubuntu/zsys/vendor/github.com/bicomsystems/go-libzfs._Cfunc_dataset_list_root(0x0)
Apr 16 21:43:58 kubuntu zsysd[12777]:         _cgo_gotypes.go:504 +0x4a fp=0xc0001133f8 sp=0xc0001133c8 pc=0x91a99a
Apr 16 21:43:58 kubuntu zsysd[12777]: github.com/ubuntu/zsys/vendor/github.com/bicomsystems/go-libzfs.DatasetOpenAll(0x203000, 0x203000, 0x203000, 0x20300000000000, 0xc000113570)
Apr 16 21:43:58 kubuntu zsysd[12777]:         github.com/ubuntu/zsys/vendor/github.com/bicomsystems/go-libzfs/zfs.go:83 +0x4c fp=0xc0001134b0 sp=0xc0001133f8 pc=0x91f61c
Apr 16 21:43:58 kubuntu zsysd[12777]: github.com/ubuntu/zsys/internal/zfs/libzfs.Adapter.DatasetOpenAll(0x4145e8, 0x100, 0xaa3b60, 0xabf401, 0xc0000b2d00)
Apr 16 21:43:58 kubuntu zsysd[12777]:         github.com/ubuntu/zsys/internal/zfs/libzfs/libzfs.go:26 +0x34 fp=0xc000113598 sp=0xc0001134b0 pc=0x9316b4
Apr 16 21:43:58 kubuntu zsysd[12777]: github.com/ubuntu/zsys/internal/zfs/libzfs.(*Adapter).DatasetOpenAll(0x103cf08, 0xc0000b2d00, 0xaebc9e, 0x2, 0xc000113660, 0x1)
Apr 16 21:43:58 kubuntu zsysd[12777]:         <autogenerated>:1 +0x33 fp=0xc0001135d0 sp=0xc000113598 pc=0x9337e3
Apr 16 21:43:58 kubuntu zsysd[12777]: github.com/ubuntu/zsys/internal/zfs.(*Zfs).Refresh(0xc000098e60, 0xbd8ae0, 0xc0000a2020, 0x2, 0xc0001136f8)
Apr 16 21:43:58 kubuntu zsysd[12777]:         github.com/ubuntu/zsys/internal/zfs/zfs.go:106 +0x17a fp=0xc0001136b0 sp=0xc0001135d0 pc=0x939f2a
Apr 16 21:43:58 kubuntu zsysd[12777]: github.com/ubuntu/zsys/internal/zfs.New(0xbd8ae0, 0xc0000a2020, 0xc0001137b8, 0x1, 0x1, 0x1, 0x1, 0xc0001137e8)
Apr 16 21:43:58 kubuntu zsysd[12777]:         github.com/ubuntu/zsys/internal/zfs/zfs.go:88 +0x158 fp=0xc000113718 sp=0xc0001136b0 pc=0x939d18
Apr 16 21:43:58 kubuntu zsysd[12777]: github.com/ubuntu/zsys/internal/machines.New(0xbd8ae0, 0xc0000a2020, 0xc00007a240, 0x5c, 0xc000113b10, 0x1, 0x1, 0x0, 0x0, 0x0, ...)
Apr 16 21:43:58 kubuntu zsysd[12777]:         github.com/ubuntu/zsys/internal/machines/machines.go:127 +0x375 fp=0xc000113950 sp=0xc000113718 pc=0x955025
Apr 16 21:43:58 kubuntu zsysd[12777]: github.com/ubuntu/zsys/internal/daemon.New(0x0, 0x0, 0x0, 0x0, 0x0, 0x6856fd, 0xc0000c87e0, 0xbc95e0)
Apr 16 21:43:58 kubuntu zsysd[12777]:         github.com/ubuntu/zsys/internal/daemon/daemon.go:115 +0x451 fp=0xc000113c88 sp=0xc000113950 pc=0x9779b1
Apr 16 21:43:58 kubuntu zsysd[12777]: github.com/ubuntu/zsys/cmd/zsysd/daemon.glob..func2(0xfd3160, 0x103cf08, 0x0, 0x0)
Apr 16 21:43:58 kubuntu zsysd[12777]:         github.com/ubuntu/zsys/cmd/zsysd/daemon/zsysd.go:30 +0x59 fp=0xc000113d18 sp=0xc000113c88 pc=0x97f5c9
Apr 16 21:43:58 kubuntu zsysd[12777]: github.com/ubuntu/zsys/vendor/github.com/spf13/cobra.(*Command).execute(0xfd3160, 0xc00008a1e0, 0x0, 0x0, 0xfd3160, 0xc00008a1e0)
Apr 16 21:43:58 kubuntu zsysd[12777]:         github.com/ubuntu/zsys/vendor/github.com/spf13/cobra/command.go:830 +0x2aa fp=0xc000113df0 sp=0xc000113d18 pc=0x5d767a
Apr 16 21:43:58 kubuntu zsysd[12777]: github.com/ubuntu/zsys/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xfd3160, 0xb, 0x7ffdff19bee6, 0x5)
Apr 16 21:43:58 kubuntu zsysd[12777]:         github.com/ubuntu/zsys/vendor/github.com/spf13/cobra/command.go:914 +0x2fb fp=0xc000113ec8 sp=0xc000113df0 pc=0x5d827b
Apr 16 21:43:58 kubuntu zsysd[12777]: github.com/ubuntu/zsys/vendor/github.com/spf13/cobra.(*Command).Execute(...)
Apr 16 21:43:58 kubuntu zsysd[12777]:         github.com/ubuntu/zsys/vendor/github.com/spf13/cobra/command.go:864
Apr 16 21:43:58 kubuntu zsysd[12777]: main.main()
Apr 16 21:43:58 kubuntu zsysd[12777]:         github.com/ubuntu/zsys/cmd/zsysd/main.go:36 +0xdb fp=0xc000113f60 sp=0xc000113ec8 pc=0x98223b
Apr 16 21:43:58 kubuntu zsysd[12777]: runtime.main()
Apr 16 21:43:58 kubuntu zsysd[12777]:         runtime/proc.go:203 +0x21e fp=0xc000113fe0 sp=0xc000113f60 pc=0x4386ce
Apr 16 21:43:58 kubuntu zsysd[12777]: runtime.goexit()
Apr 16 21:43:58 kubuntu zsysd[12777]:         runtime/asm_amd64.s:1357 +0x1 fp=0xc000113fe8 sp=0xc000113fe0 pc=0x4667c1
Apr 16 21:43:58 kubuntu zsysd[12777]: goroutine 19 [runnable]:
Apr 16 21:43:58 kubuntu zsysd[12777]: os/signal.loop()
Apr 16 21:43:58 kubuntu zsysd[12777]:         os/signal/signal_unix.go:21
Apr 16 21:43:58 kubuntu zsysd[12777]: created by os/signal.init.0
Apr 16 21:43:58 kubuntu zsysd[12777]:         os/signal/signal_unix.go:29 +0x41
Apr 16 21:43:58 kubuntu systemd[1]: zsysd.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Apr 16 21:43:58 kubuntu systemd[1]: zsysd.service: Failed with result 'exit-code'.
Apr 16 21:43:58 kubuntu systemd[1]: Failed to start ZSYS daemon service.
[--- not copied here: systemd attempts several more restarts ---]
Apr 16 21:48:29 kubuntu systemd[1]: zsysd.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Apr 16 21:48:29 kubuntu systemd[1]: zsysd.service: Failed with result 'exit-code'.
Apr 16 21:48:29 kubuntu systemd[1]: Failed to start ZSYS daemon service.
Apr 16 21:48:29 kubuntu systemd[1]: zsysd.service: Start request repeated too quickly.
Apr 16 21:48:29 kubuntu systemd[1]: zsysd.service: Failed with result 'exit-code'.
Apr 16 21:48:29 kubuntu systemd[1]: Failed to start ZSYS daemon service.
```

I first noticed this when trying to install several of the ZFS packages at once:
```console
$ sudo apt install zfsutils-linux zfs-initramfs zsys
```
Zsys intermittently failed to start right after installation even in the above scenario due to a race condition where apt would sometimes attempt to start zsys before installing zfsutils-linux, since it did not see the latter as a dependency of the former.

This PR declares the missing dependency to fix this race condition.
