### PR TITLE
Removal without purge should not warn

### DIFF
--- a/debian/90_zsys_system_autosnapshot
+++ b/debian/90_zsys_system_autosnapshot
@@ -1,4 +1,4 @@
 // Takes a snapshot of the system before package changes.
-DPkg::Pre-Invoke {"/usr/libexec/zsys-system-autosnapshot snapshot || true";};
+DPkg::Pre-Invoke {"[ -x /usr/libexec/zsys-system-autosnapshot ] && /usr/libexec/zsys-system-autosnapshot snapshot || true";};
 // Update our bootloader to list the new snapshot after the update is done to not block the critical path
-DPkg::Post-Invoke {"/usr/libexec/zsys-system-autosnapshot update-menu || true";};
+DPkg::Post-Invoke {"[ -x /usr/libexec/zsys-system-autosnapshot ] && /usr/libexec/zsys-system-autosnapshot update-menu || true";};


### PR DESCRIPTION
Protect by checking the binary exists on disk first.