### PR TITLE
Switch to focal ubuntu image for CI generation check

### DIFF
--- a/.github/workflows/repo-quality.yaml
+++ b/.github/workflows/repo-quality.yaml
@@ -53,7 +53,7 @@ jobs:
   generators:
     name: Generated files are up to date
     runs-on: ubuntu-latest
-    container: ubuntu:devel
+    container: ubuntu:latest
     steps:
       # Add dependencies
       - name: Install dependencies


### PR DESCRIPTION
Protobuf version in gorilla seems incompatible (missing Close method)