### PR TITLE
Get better timeout handling logic

### DIFF
--- a/cmd/zsysd/client/boot.go
+++ b/cmd/zsysd/client/boot.go
@@ -63,7 +63,7 @@ func bootPrepare(printModifiedBoot bool) (err error) {
 	defer cancel()
 
 	stream, err := client.PrepareBoot(ctx, &zsys.Empty{})
-	if err = checkConn(err); err != nil {
+	if err = checkConn(err, reset); err != nil {
 		return err
 	}
 
@@ -104,7 +104,7 @@ func bootCommit(printModifiedBoot bool) (err error) {
 	defer cancel()
 
 	stream, err := client.CommitBoot(ctx, &zsys.Empty{})
-	if err = checkConn(err); err != nil {
+	if err = checkConn(err, reset); err != nil {
 		return err
 	}
 
@@ -145,7 +145,7 @@ func updateBootMenu(auto bool) error {
 	defer cancel()
 
 	stream, err := client.UpdateBootMenu(ctx, &zsys.UpdateBootMenuRequest{Auto: auto})
-	if err = checkConn(err); err != nil {
+	if err = checkConn(err, reset); err != nil {
 		return err
 	}
 

--- a/cmd/zsysd/client/common.go
+++ b/cmd/zsysd/client/common.go
@@ -24,23 +24,32 @@ func newClient() (*zsys.ZsysLogClient, error) {
 	return c, nil
 }
 
-// checkConn checks for unavailable service and unwrap any other rpc error to its message.
-func checkConn(err error) error {
+// checkConn checks for unavailable service and unwrap any other rpc error to its message and reset timeout timer.
+func checkConn(err error, reset chan<- struct{}) error {
 	if err != nil {
-		st, _ := status.FromError(err)
-		if st.Code() == codes.Unavailable {
+		switch st := status.Convert(err); st.Code() {
+		case codes.Unavailable:
 			return fmt.Errorf(i18n.G("couldn't connect to zsys daemon: %v"), st.Message())
+		case codes.Canceled:
+			return context.Canceled
+		default:
+			return errors.New(st.Message())
 		}
-		return errors.New(st.Message())
 	}
 
+	reset <- struct{}{}
 	return nil
 }
 
-// contextWithResettableTimeout returns a context that can be cancelled manually reset to timeout value sending an element to the returned channel
-func contextWithResettableTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc, chan<- struct{}) {
+// contextWithResettableTimeout returns a cancellable context that can be manually reset to timeout value
+// when sending an element to the returned channel.
+// Note that the first request is longer, letting the service accepting the new request (and optionally loading).
+func contextWithResettableTimeout(ctx context.Context, requestTimeout time.Duration) (context.Context, context.CancelFunc, chan<- struct{}) {
 	ctx, cancel := context.WithCancel(ctx)
 	reset := make(chan struct{})
+
+	// First request can be longer until the service is ready and send a first reset on connexion ack
+	timeout := config.DefaultClientWaitOnServiceReady
 
 	go func() {
 		for {
@@ -51,6 +60,7 @@ func contextWithResettableTimeout(ctx context.Context, timeout time.Duration) (c
 				break
 			case <-reset:
 			}
+			timeout = requestTimeout
 		}
 	}()
 

--- a/cmd/zsysd/client/machine.go
+++ b/cmd/zsysd/client/machine.go
@@ -66,7 +66,7 @@ func show(args []string) error {
 
 	stream, err := client.MachineShow(ctx, &zsys.MachineShowRequest{MachineId: machineID, Full: fullInfo})
 
-	if err = checkConn(err); err != nil {
+	if err = checkConn(err, reset); err != nil {
 		return err
 	}
 
@@ -99,7 +99,7 @@ func list(args []string) error {
 
 	stream, err := client.MachineList(ctx, &zsys.Empty{})
 
-	if err = checkConn(err); err != nil {
+	if err = checkConn(err, reset); err != nil {
 		return err
 	}
 

--- a/cmd/zsysd/client/service.go
+++ b/cmd/zsysd/client/service.go
@@ -111,7 +111,7 @@ func daemonStop() error {
 	defer cancel()
 
 	stream, err := client.DaemonStop(ctx, &zsys.Empty{})
-	if err = checkConn(err); err != nil {
+	if err = checkConn(err, reset); err != nil {
 		return err
 	}
 
@@ -143,7 +143,7 @@ func dumpService() error {
 	defer cancel()
 
 	stream, err := client.DumpStates(ctx, &zsys.Empty{})
-	if err = checkConn(err); err != nil {
+	if err = checkConn(err, reset); err != nil {
 		return err
 	}
 
@@ -181,7 +181,7 @@ func loggingLevel(args []string) error {
 	defer cancel()
 
 	stream, err := client.LoggingLevel(ctx, &zsys.LoggingLevelRequest{Logginglevel: int32(level)})
-	if err = checkConn(err); err != nil {
+	if err = checkConn(err, reset); err != nil {
 		return err
 	}
 
@@ -213,7 +213,7 @@ func refresh() error {
 	defer cancel()
 
 	stream, err := client.Refresh(ctx, &zsys.Empty{})
-	if err = checkConn(err); err != nil {
+	if err = checkConn(err, reset); err != nil {
 		return err
 	}
 
@@ -286,7 +286,7 @@ func trace() error {
 		Duration: int32(traceDuration),
 	})
 
-	if err = checkConn(err); err != nil {
+	if err = checkConn(err, nil); err != nil {
 		return err
 	}
 
@@ -322,7 +322,7 @@ func daemonStatus() error {
 	defer cancel()
 
 	stream, err := client.Status(ctx, &zsys.Empty{})
-	if err = checkConn(err); err != nil {
+	if err = checkConn(err, reset); err != nil {
 		return err
 	}
 
@@ -354,7 +354,7 @@ func reloadConfig() error {
 	defer cancel()
 
 	stream, err := client.Reload(ctx, &zsys.Empty{})
-	if err = checkConn(err); err != nil {
+	if err = checkConn(err, reset); err != nil {
 		return err
 	}
 
@@ -386,7 +386,7 @@ func gc(gcAll bool) error {
 	defer cancel()
 
 	stream, err := client.GC(ctx, &zsys.GCRequest{All: gcAll})
-	if err = checkConn(err); err != nil {
+	if err = checkConn(err, reset); err != nil {
 		return err
 	}
 

--- a/cmd/zsysd/client/service.go
+++ b/cmd/zsysd/client/service.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -108,7 +107,7 @@ func daemonStop() error {
 	}
 	defer client.Close()
 
-	ctx, cancel := context.WithTimeout(client.Ctx, config.DefaultClientTimeout)
+	ctx, cancel, reset := contextWithResettableTimeout(client.Ctx, config.DefaultClientTimeout)
 	defer cancel()
 
 	stream, err := client.DaemonStop(ctx, &zsys.Empty{})
@@ -119,6 +118,7 @@ func daemonStop() error {
 	for {
 		_, err := stream.Recv()
 		if err == streamlogger.ErrLogMsg {
+			reset <- struct{}{}
 			continue
 		}
 		if err == io.EOF {
@@ -139,7 +139,7 @@ func dumpService() error {
 	}
 	defer client.Close()
 
-	ctx, cancel := context.WithTimeout(client.Ctx, config.DefaultClientTimeout)
+	ctx, cancel, reset := contextWithResettableTimeout(client.Ctx, config.DefaultClientTimeout)
 	defer cancel()
 
 	stream, err := client.DumpStates(ctx, &zsys.Empty{})
@@ -150,6 +150,7 @@ func dumpService() error {
 	for {
 		r, err := stream.Recv()
 		if err == streamlogger.ErrLogMsg {
+			reset <- struct{}{}
 			continue
 		}
 		if err == io.EOF {
@@ -176,7 +177,7 @@ func loggingLevel(args []string) error {
 	}
 	defer client.Close()
 
-	ctx, cancel := context.WithTimeout(client.Ctx, config.DefaultClientTimeout)
+	ctx, cancel, reset := contextWithResettableTimeout(client.Ctx, config.DefaultClientTimeout)
 	defer cancel()
 
 	stream, err := client.LoggingLevel(ctx, &zsys.LoggingLevelRequest{Logginglevel: int32(level)})
@@ -187,6 +188,7 @@ func loggingLevel(args []string) error {
 	for {
 		_, err := stream.Recv()
 		if err == streamlogger.ErrLogMsg {
+			reset <- struct{}{}
 			continue
 		}
 		if err == io.EOF {
@@ -207,7 +209,7 @@ func refresh() error {
 	}
 	defer client.Close()
 
-	ctx, cancel := context.WithTimeout(client.Ctx, config.DefaultClientTimeout)
+	ctx, cancel, reset := contextWithResettableTimeout(client.Ctx, config.DefaultClientTimeout)
 	defer cancel()
 
 	stream, err := client.Refresh(ctx, &zsys.Empty{})
@@ -218,6 +220,7 @@ func refresh() error {
 	for {
 		_, err := stream.Recv()
 		if err == streamlogger.ErrLogMsg {
+			reset <- struct{}{}
 			continue
 		}
 		if err == io.EOF {
@@ -315,7 +318,7 @@ func daemonStatus() error {
 	}
 	defer client.Close()
 
-	ctx, cancel := context.WithTimeout(client.Ctx, config.DefaultClientTimeout)
+	ctx, cancel, reset := contextWithResettableTimeout(client.Ctx, config.DefaultClientTimeout)
 	defer cancel()
 
 	stream, err := client.Status(ctx, &zsys.Empty{})
@@ -326,6 +329,7 @@ func daemonStatus() error {
 	for {
 		_, err := stream.Recv()
 		if err == streamlogger.ErrLogMsg {
+			reset <- struct{}{}
 			continue
 		}
 		if err == io.EOF {
@@ -346,7 +350,7 @@ func reloadConfig() error {
 	}
 	defer client.Close()
 
-	ctx, cancel := context.WithTimeout(client.Ctx, config.DefaultClientTimeout)
+	ctx, cancel, reset := contextWithResettableTimeout(client.Ctx, config.DefaultClientTimeout)
 	defer cancel()
 
 	stream, err := client.Reload(ctx, &zsys.Empty{})
@@ -357,6 +361,7 @@ func reloadConfig() error {
 	for {
 		_, err := stream.Recv()
 		if err == streamlogger.ErrLogMsg {
+			reset <- struct{}{}
 			continue
 		}
 		if err == io.EOF {
@@ -377,7 +382,7 @@ func gc(gcAll bool) error {
 	}
 	defer client.Close()
 
-	ctx, cancel := context.WithTimeout(client.Ctx, config.DefaultClientTimeout)
+	ctx, cancel, reset := contextWithResettableTimeout(client.Ctx, config.DefaultClientTimeout)
 	defer cancel()
 
 	stream, err := client.GC(ctx, &zsys.GCRequest{All: gcAll})
@@ -388,6 +393,7 @@ func gc(gcAll bool) error {
 	for {
 		_, err := stream.Recv()
 		if err == streamlogger.ErrLogMsg {
+			reset <- struct{}{}
 			continue
 		}
 		if err == io.EOF {

--- a/cmd/zsysd/client/state.go
+++ b/cmd/zsysd/client/state.go
@@ -100,7 +100,7 @@ func saveState(args []string, system bool, userName string, noUpdateBootMenu, sa
 			Autosave:       saveAuto,
 		})
 
-		if err = checkConn(err); err != nil {
+		if err = checkConn(err, reset); err != nil {
 			return err
 		}
 
@@ -130,7 +130,7 @@ func saveState(args []string, system bool, userName string, noUpdateBootMenu, sa
 
 		stream, err := client.SaveUserState(ctx, &zsys.SaveUserStateRequest{UserName: userName, StateName: stateName})
 
-		if err = checkConn(err); err != nil {
+		if err = checkConn(err, reset); err != nil {
 			return err
 		}
 
@@ -239,7 +239,7 @@ func removeStateGRPC(client *zsys.ZsysLogClient, force, dryrun, system bool, use
 			Dryrun:    dryrun,
 		})
 
-		if err = checkConn(err); err != nil {
+		if err = checkConn(err, reset); err != nil {
 			return err
 		}
 
@@ -265,7 +265,7 @@ func removeStateGRPC(client *zsys.ZsysLogClient, force, dryrun, system bool, use
 			Dryrun:    dryrun,
 		})
 
-		if err = checkConn(err); err != nil {
+		if err = checkConn(err, reset); err != nil {
 			return err
 		}
 

--- a/cmd/zsysd/client/userdata.go
+++ b/cmd/zsysd/client/userdata.go
@@ -52,7 +52,7 @@ func createUserData(user, homepath string) (err error) {
 	defer cancel()
 
 	stream, err := client.CreateUserData(ctx, &zsys.CreateUserDataRequest{User: user, Homepath: homepath})
-	if err = checkConn(err); err != nil {
+	if err = checkConn(err, reset); err != nil {
 		return err
 	}
 
@@ -85,7 +85,7 @@ func changeHomeOnUserData(home, newHome string) (err error) {
 	defer cancel()
 
 	stream, err := client.ChangeHomeOnUserData(ctx, &zsys.ChangeHomeOnUserDataRequest{Home: home, NewHome: newHome})
-	if err = checkConn(err); err != nil {
+	if err = checkConn(err, reset); err != nil {
 		return err
 	}
 

--- a/cmd/zsysd/client/version.go
+++ b/cmd/zsysd/client/version.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"fmt"
 	"io"
 
@@ -35,7 +34,7 @@ func getVersion() (err error) {
 	}
 	defer client.Close()
 
-	ctx, cancel := context.WithTimeout(client.Ctx, config.DefaultClientTimeout)
+	ctx, cancel, reset := contextWithResettableTimeout(client.Ctx, config.DefaultClientTimeout)
 	defer cancel()
 
 	stream, err := client.Version(ctx, &zsys.Empty{})
@@ -46,6 +45,7 @@ func getVersion() (err error) {
 	for {
 		r, err := stream.Recv()
 		if err == streamlogger.ErrLogMsg {
+			reset <- struct{}{}
 			continue
 		}
 		if err == io.EOF {

--- a/cmd/zsysd/client/version.go
+++ b/cmd/zsysd/client/version.go
@@ -38,7 +38,7 @@ func getVersion() (err error) {
 	defer cancel()
 
 	stream, err := client.Version(ctx, &zsys.Empty{})
-	if err = checkConn(err); err != nil {
+	if err = checkConn(err, reset); err != nil {
 		return err
 	}
 

--- a/cmd/zsysd/main.go
+++ b/cmd/zsysd/main.go
@@ -45,7 +45,7 @@ func main() {
 	}
 	err := errFunc()
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
+		if errors.Is(err, context.Canceled) {
 			err = errors.New(i18n.G("Service took too long to respond. Disconnecting client."))
 		}
 		log.Error(err)

--- a/internal/config/const.go
+++ b/internal/config/const.go
@@ -11,8 +11,8 @@ const (
 	// DefaultSocket path.
 	DefaultSocket = "/run/zsysd.sock"
 
-	// DefaultClientTimeout for client requests
-	DefaultClientTimeout = 120 * time.Second
+	// DefaultClientTimeout for client requests between 2 pings
+	DefaultClientTimeout = 30 * time.Second
 
 	// DefaultServerIdleTimeout is the default time without a request before the server exits
 	DefaultServerIdleTimeout = time.Minute

--- a/internal/config/const.go
+++ b/internal/config/const.go
@@ -11,8 +11,10 @@ const (
 	// DefaultSocket path.
 	DefaultSocket = "/run/zsysd.sock"
 
+	// DefaultClientWaitOnServiceReady for client on waiting on service to start
+	DefaultClientWaitOnServiceReady = time.Minute
 	// DefaultClientTimeout for client requests between 2 pings
-	DefaultClientTimeout = 30 * time.Second
+	DefaultClientTimeout = 1 * time.Second
 
 	// DefaultServerIdleTimeout is the default time without a request before the server exits
 	DefaultServerIdleTimeout = time.Minute

--- a/internal/log/create.go
+++ b/internal/log/create.go
@@ -24,6 +24,12 @@ const (
 	defaultRequestID = "unknown"
 )
 
+var (
+	// PingLogMessage is when we need to only transmit a ping to the client telling we are still alive
+	PingLogMessage     = "."
+	bytePingLogMessage = []byte(PingLogMessage)
+)
+
 // ContextWithLogger returns a context which will log to the writer.
 // Level is based on metadata information from the ctx request.
 // A generated request ID is added to a requester ID and attached to the context

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -60,7 +60,11 @@ func Debug(ctx context.Context, args ...interface{}) {
 // and may push to the stream may push to the stream referenced by ctx.
 func Debugf(ctx context.Context, format string, args ...interface{}) {
 	if info, ok := ctx.Value(requestInfoKey).(*requestInfo); ok {
-		info.logger.Debugf(format, args...)
+		if info.logger.Level >= DebugLevel {
+			info.logger.Debugf(format, args...)
+		} else {
+			info.logger.Out.Write(bytePingLogMessage)
+		}
 		// for standard logger, save the id
 		format = fmt.Sprintf(reqIDFormat, info.id, format)
 	}
@@ -77,7 +81,11 @@ func Info(ctx context.Context, args ...interface{}) {
 // and may push to the stream may push to the stream referenced by ctx.
 func Infof(ctx context.Context, format string, args ...interface{}) {
 	if info, ok := ctx.Value(requestInfoKey).(*requestInfo); ok {
-		info.logger.Infof(format, args...)
+		if info.logger.Level >= InfoLevel {
+			info.logger.Infof(format, args...)
+		} else {
+			info.logger.Out.Write(bytePingLogMessage)
+		}
 		// for standard logger, save the id
 		format = fmt.Sprintf(reqIDFormat, info.id, format)
 	}
@@ -108,7 +116,11 @@ func Warning(ctx context.Context, args ...interface{}) {
 // and may push to the stream may push to the stream referenced by ctx.
 func Warningf(ctx context.Context, format string, args ...interface{}) {
 	if info, ok := ctx.Value(requestInfoKey).(*requestInfo); ok {
-		info.logger.Warningf(format, args...)
+		if info.logger.Level >= DefaultLevel {
+			info.logger.Warningf(format, args...)
+		} else {
+			info.logger.Out.Write(bytePingLogMessage)
+		}
 		// for standard logger, save the id
 		format = fmt.Sprintf(reqIDFormat, info.id, format)
 	}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -94,10 +94,7 @@ func RemotePrint(ctx context.Context, args ...interface{}) {
 // client end stream referenced by ctx.
 func RemotePrintf(ctx context.Context, format string, args ...interface{}) {
 	if info, ok := ctx.Value(requestInfoKey).(*requestInfo); ok {
-		l := info.logger.GetLevel()
-		info.logger.SetLevel(InfoLevel)
-		info.logger.Printf(format, args...)
-		info.logger.SetLevel(l)
+		info.logger.Out.Write([]byte(fmt.Sprintf(format, args...)))
 	}
 }
 

--- a/internal/streamlogger/client.go
+++ b/internal/streamlogger/client.go
@@ -112,6 +112,8 @@ func (w *clientRequestLogStream) RecvMsg(m interface{}) (errFn error) {
 		return nil
 	}
 
-	fmt.Fprint(os.Stderr, l)
+	if l != log.PingLogMessage {
+		fmt.Fprint(os.Stderr, l)
+	}
 	return ErrLogMsg
 }

--- a/internal/streamlogger/client.go
+++ b/internal/streamlogger/client.go
@@ -94,7 +94,10 @@ func (w *clientRequestLogStream) RecvMsg(m interface{}) (errFn error) {
 		return err
 	}
 	if err != nil {
-		if st := status.Convert(err); st.Code() == codes.Unknown {
+		switch st := status.Convert(err); st.Code() {
+		case codes.Canceled:
+			return context.Canceled
+		case codes.Unknown:
 			return errors.New(st.Message())
 		}
 		return err


### PR DESCRIPTION
This covers timeout when doing the initial request. It has a slight different logic for timeouts in the in flight request (regular ping).

Reduce thus the default inactivity timer and enhance direct printing to user (without INFO).