### PR TITLE
Fix CI lint in cmdhandler package

### DIFF
--- a/cmd/zsysd/cmdhandler/suggest.go
+++ b/cmd/zsysd/cmdhandler/suggest.go
@@ -22,7 +22,7 @@ func SubcommandsRequiredWithSuggestions(cmd *cobra.Command, args []string) error
 			cmd.SuggestionsMinimumDistance = 2
 		}
 		// subcommand suggestions
-		suggestions = append(cmd.SuggestionsFor(args[0]))
+		suggestions = cmd.SuggestionsFor(args[0])
 
 		// subcommand alias suggestions (with distance, not exact)
 		for _, c := range cmd.Commands() {


### PR DESCRIPTION
On running golangci-lint we get a linting error `SA4021: x = append(y) is equivalent to x = y (staticcheck)` 
This PR will fix this linting error.

Signed-off-by: vinamra28 <vinjain@redhat.com>