### PR TITLE
Verify that name of snapshot is valid.

### DIFF
--- a/internal/daemon/state.go
+++ b/internal/daemon/state.go
@@ -69,7 +69,6 @@ func (s *Server) SaveSystemState(req *zsys.SaveSystemStateRequest, stream zsys.Z
 // userName is the name of the user to snapshot the datasets from.
 func (s *Server) SaveUserState(req *zsys.SaveUserStateRequest, stream zsys.Zsys_SaveUserStateServer) (err error) {
 	userName := req.GetUserName()
-	fmt.Println(userName)
 
 	if err := s.authorizer.IsAllowedFromContext(context.WithValue(stream.Context(), authorizer.OnUserKey, userName),
 		authorizer.ActionUserWrite); err != nil {

--- a/internal/machines/machines_test.go
+++ b/internal/machines/machines_test.go
@@ -955,6 +955,9 @@ func TestCreateSystemSnapshot(t *testing.T) {
 		"Error on existing snapshot on user root":    {def: "m_with_userdata_and_multiple_snapshots.yaml", snapshotName: "user_root_snapshot", wantErr: true, isNoOp: true},
 		"Error on existing snapshot on user child":   {def: "m_with_userdata_and_multiple_snapshots.yaml", snapshotName: "user_child_snapshot", wantErr: true, isNoOp: true},
 
+		"Error when name starts with dash":            {def: "m_with_userdata.yaml", snapshotName: "-my_snapshot", wantErr: true, isNoOp: true},
+		"Error when name contains invalid characters": {def: "m_with_userdata.yaml", snapshotName: "my snäpshôt,", wantErr: true, isNoOp: true},
+
 		"Non zsys":   {def: "m_with_userdata_no_zsys.yaml", wantErr: true, isNoOp: true},
 		"No machine": {def: "m_with_userdata_no_zsys.yaml", cmdline: generateCmdLine("rpool/ROOT/nomachine"), wantErr: true, isNoOp: true},
 	}


### PR DESCRIPTION
When saving a state, verify that the name contains only allowed
characters. Even if space if not forbidden, it is not supported by grub
and init, so reject it too.

Co-authored-by: Didier Roche <didrocks@ubuntu.com>