### PR TITLE
Deduplicate list of invalid characters in snapshot name

### DIFF
--- a/internal/machines/machines_test.go
+++ b/internal/machines/machines_test.go
@@ -956,7 +956,7 @@ func TestCreateSystemSnapshot(t *testing.T) {
 		"Error on existing snapshot on user child":   {def: "m_with_userdata_and_multiple_snapshots.yaml", snapshotName: "user_child_snapshot", wantErr: true, isNoOp: true},
 
 		"Error when name starts with dash":            {def: "m_with_userdata.yaml", snapshotName: "-my_snapshot", wantErr: true, isNoOp: true},
-		"Error when name contains invalid characters": {def: "m_with_userdata.yaml", snapshotName: "my snäpshôt,", wantErr: true, isNoOp: true},
+		"Error when name contains invalid characters": {def: "m_with_userdata.yaml", snapshotName: "my, snäpshôt, is beautiful,", wantErr: true, isNoOp: true},
 
 		"Non zsys":   {def: "m_with_userdata_no_zsys.yaml", wantErr: true, isNoOp: true},
 		"No machine": {def: "m_with_userdata_no_zsys.yaml", cmdline: generateCmdLine("rpool/ROOT/nomachine"), wantErr: true, isNoOp: true},

--- a/internal/machines/snapshot.go
+++ b/internal/machines/snapshot.go
@@ -115,7 +115,17 @@ func validateStateName(stateName string) error {
 		}
 	}
 	if invalidChars != nil {
-		return fmt.Errorf(i18n.G("the following characters are not supported in state name: '%s'"), strings.Join(invalidChars, "','"))
+		// Deduplicate list of invalid chars so they appear only once in error message
+		keys := make(map[string]bool)
+		uniqueChars := []string{}
+
+		for _, c := range invalidChars {
+			if _, v := keys[c]; !v {
+				keys[c] = true
+				uniqueChars = append(uniqueChars, c)
+			}
+		}
+		return fmt.Errorf(i18n.G("the following characters are not supported in state name: '%s'"), strings.Join(uniqueChars, "','"))
 	}
 
 	return nil


### PR DESCRIPTION
If an invalid character appears multiple times in the name of a snapshot
it was listed several times in the error message. This is a cosmetic fix
to list each only once.

Co-authored-by: Didier Roche <didrocks@ubuntu.com>