### PR TITLE
Add Short description to command aliases

### DIFF
--- a/cmd/zsysd/cmdhandler/common.go
+++ b/cmd/zsysd/cmdhandler/common.go
@@ -15,7 +15,7 @@ func NoCmd(cmd *cobra.Command, args []string) {
 // README and manpage refers to them in each subsection (parents are differents, but only one is kept if we use the same object)
 func RegisterAlias(cmd, parent *cobra.Command) {
 	alias := *cmd
-	t := fmt.Sprintf(i18n.G("Alias of %s"), cmd.CommandPath())
+	t := fmt.Sprintf(i18n.G("Alias of %s. %s"), cmd.CommandPath(), cmd.Short)
 	if alias.Long != "" {
 		t = fmt.Sprintf("%s (%s)", alias.Long, t)
 	}


### PR DESCRIPTION
Improves #238 by adding the `Short` description to aliases; for example,

    Alias of zsysctl state save

becomes

    Alias of zsysctl state save. Saves the current state of the machine. By default it saves only the user state. state_id is generated if not provided.