### PR TITLE
debian/control: limit arches to known working subset

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ XS-Go-Import-Path: github.com/ubuntu/zsys
 Homepage: https://github.com/ubuntu/zsys
 
 Package: zsys
-Architecture: any
+Architecture: amd64 arm64 ppc64el riscv64
 Built-Using: ${misc:Built-Using},
 Depends: ${shlibs:Depends},
          ${misc:Depends},


### PR DESCRIPTION
armhf fails unittesting, hasn't been built for many releases. s390x doesn't have grub and zsys doesn't have sipl integration. this commit prevents wasting resources and time of launching builder VMs to never produce anything.